### PR TITLE
use css loader instead of scss loader

### DIFF
--- a/src/Chartjs.vue
+++ b/src/Chartjs.vue
@@ -70,7 +70,7 @@ export default {
 }
 </script>
 
-<style lang="scss">
+<style lang="css">
   canvas.chartjs {
     max-width: 100%;
   }


### PR DESCRIPTION
There's no reason using scss-loader (which is seems to be an alpha version) for just 3 line of css.